### PR TITLE
Update linked_list_allocator to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ version = "0.3.1"
 
 [dependencies]
 cortex-m = "0.1.5"
-linked_list_allocator = "0.4.2"
+linked_list_allocator = "0.5.0"


### PR DESCRIPTION
This version removes all uses of the deprecated `Unique` wrapper, which is moved behind a new feature gate on recent nightlies and thus causes compilation failures.