### PR TITLE
Panic on out of memory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,4 +110,8 @@ unsafe impl<'a> Alloc for &'a CortexMHeap {
     unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout) {
         self.heap.lock(|heap| heap.deallocate(ptr, layout));
     }
+    
+    fn oom(&mut self, _: AllocErr) -> ! {
+        panic!("Out of memory");
+    }
 }


### PR DESCRIPTION
The default implementation calls `::core::intrinsics::abort`, which results in an exception on Cortex M. I think a panic would be better to debug.