### PR TITLE
Disable default features on linked_list_allocator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,7 @@ version = "0.3.2"
 
 [dependencies]
 cortex-m = "0.1.5"
-linked_list_allocator = "0.5.0"
+
+[dependencies.linked_list_allocator]
+version = "0.5.0"
+default-features = false


### PR DESCRIPTION
By default, linked_list_allocator depends on spin which eventually ends
up depending on atomics. This breaks support for Cortex-M0 that doesn't
have such atomics. However, alloc_cortex_m didn't need this
functionality anyways, so just disable it.