### PR TITLE
Use new global allocator API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ version = "0.3.2"
 
 [dependencies]
 cortex-m = "0.1.5"
-linked_list_allocator = "0.5.0"
+linked_list_allocator = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,22 +47,21 @@
 #![no_std]
 #![feature(alloc, allocator_api)]
 
+extern crate alloc;
 extern crate cortex_m;
 extern crate linked_list_allocator;
-extern crate alloc;
 
 use core::alloc::{GlobalAlloc, Layout, Opaque};
 use core::ptr::NonNull;
 
-use linked_list_allocator::Heap;
 use cortex_m::interrupt::Mutex;
+use linked_list_allocator::Heap;
 
 pub struct CortexMHeap {
     heap: Mutex<Heap>,
 }
 
 impl CortexMHeap {
-
     /// Crate a new UNINITIALIZED heap allocator
     ///
     /// You must initialize this heap using the
@@ -96,19 +95,21 @@ impl CortexMHeap {
     ///
     /// - This function must be called exactly ONCE.
     /// - `size > 0`
-    pub unsafe fn init(&self, start_addr: usize, size: usize){
+    pub unsafe fn init(&self, start_addr: usize, size: usize) {
         self.heap.lock(|heap| heap.init(start_addr, size));
     }
 }
 
 unsafe impl GlobalAlloc for CortexMHeap {
     unsafe fn alloc(&self, layout: Layout) -> *mut Opaque {
-        self.heap.lock(|heap| {
-            heap.allocate_first_fit(layout)
-        }).ok().map_or(0 as *mut Opaque, |allocation| allocation.as_ptr())
+        self.heap
+            .lock(|heap| heap.allocate_first_fit(layout))
+            .ok()
+            .map_or(0 as *mut Opaque, |allocation| allocation.as_ptr())
     }
 
     unsafe fn dealloc(&self, ptr: *mut Opaque, layout: Layout) {
-        self.heap.lock(|heap| heap.deallocate(NonNull::new_unchecked(ptr), layout));
+        self.heap
+            .lock(|heap| heap.deallocate(NonNull::new_unchecked(ptr), layout));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@
 //! ```
 //! // Plug in the allocator crate
 //! extern crate alloc_cortex_m;
-//! extern crate collections;
+//! extern crate alloc;
 //!
-//! use collections::Vec;
+//! use alloc::Vec;
 //! use alloc_cortex_m::CortexMHeap;
 //!
 //! #[global_allocator]


### PR DESCRIPTION
The global allocator API was changed in https://github.com/rust-lang/rust/pull/49669. This PR updates the `linked_list_allocator` to version 0.6.0 and implements the new `GlobalAlloc` trait for `CortexMHeap` instead of `Alloc` for `&CortexMHeap`.